### PR TITLE
Фикс навыка кровотечение

### DIFF
--- a/afliction.php
+++ b/afliction.php
@@ -5,7 +5,7 @@ $player_do = '';
 if ($npc_aff_bleed_time[$npccount] > $cur_time) //
 {
 
- $dmg = -rand($npc_aff_bleed_power[$npccount]/2+5,$npc_aff_bleed_power[$npccount]+5); 
+ $dmg = -round($npc_maxhp[$npccount]*0.03);
  $text= "[<b>$npc_name[$npccount]</b>, жизни <font class=dmg>$dmg</font>]&nbsp;<i><b>$npc_name[$npccount]</b> истекает кровью.</i>";
  $ptext .= "window.top.add(\"$time\",\"\",\"$text\",5,\"\");";
  $npchp += $dmg;

--- a/effect.php
+++ b/effect.php
@@ -9,8 +9,8 @@ if ($aff_cut > $cur_time) //
  	$aff .= "window.top.aflict($count,2);";
 if ($aff_bleed_time > $cur_time) //
 {
- $dmg = -rand($aff_bleed_power/2+5,$aff_bleed_power+5); 
- $dmg = round($dmg / (1+$race_bleed[$player_race]));
+	$dmg = -round($player_max_hp*0.03);
+	$dmg = round($dmg / (1+$race_bleed[$player_race]));
  if ($race_bleed[$player_race] > 0)
 	 $dmg=round($dmg/3);
  $text= "[<b>$player_name</b>, жизни <font class=dmg>$dmg</font>]&nbsp;<i><b>$player_name</b> истекает кровью.</i>";


### PR DESCRIPTION
**Исравление**
Изменяет урон от эффекта "Кровотечение" 
_Ранее:_  Значение использовало константу и случайное значение
_Сейчас:_  Значение использует максимальное здоровье цели * 0.03 (3%) 

**Затрагиваемые умения:** 
Владение мечем
Владение кинжалом
Владение луком
Телепатия -> Боль 

**Влияние** 
На текущий момент эффект "Кровотечения" теряет свой смысл после до 20 уровня.  Здоровье растет, а урон остается на старом уровне. Таким образом он становится бесполезным. А навыки к прокачке сомнительные. 

-  Цели эффекта теперь теряют от 9 до 15% здоровья вне зависимости от уровня и в зависимости от количества тиков в умении. Урон растет равномерно в зависимости от уровней цели. 
- Сам эффект становится более критичным, таким образом затрагивается и умение "Лечение ран" в "Магии тела". Количество энергии затрачиваемое на снятие эффекта покрывает количество урона. 
- Эффект актуален вне зависимости от уровня противника 

**Негативное влияние** 
- Эффект становится менее актуальным на низких уровнях, в виду его пропорциональности. Ранее он смог сносить даже по 30% здоровья на 0-1 уровнях
- Реальный рост урона становится заметным где-то после 50 уровня в ПВЕ. 


